### PR TITLE
Enhance connector functionality to support project scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ client.custom_tools.delete("tool_id")
 ```python
 # Add database connector
 connector = client.connectors.create(
+    project_id=project.id,
     name="Production DB",
     db_type="postgres",
     host="localhost",
@@ -247,7 +248,7 @@ connector = client.connectors.create(
 )
 
 # Test connection
-result = client.connectors.test_connection(connector.id)
+result = client.connectors.test_connection(project.id, connector.id)
 ```
 
 ## Error Handling

--- a/docs/guides/connectors.md
+++ b/docs/guides/connectors.md
@@ -10,8 +10,10 @@ from text2everything_sdk import Text2EverythingClient
 
 client = Text2EverythingClient(base_url="https://...", access_token="...", workspace_name="workspaces/dev")
 
-# Create
+# Create in a project
+project_id = client.projects.create(name="Demo").id
 conn = client.connectors.create(
+    project_id=project_id,
     name="Production DB",
     db_type="postgres",
     host="db.example.com",
@@ -21,20 +23,20 @@ conn = client.connectors.create(
     database="production",
 )
 
-# List / get
-connectors = client.connectors.list()
-one = client.connectors.get(conn.id)
+# List / get in project
+connectors = client.connectors.list(project_id)
+one = client.connectors.get(project_id, conn.id)
 
 # Update
-updated = client.connectors.update(conn.id, port=5433, description="Updated")
+updated = client.connectors.update(project_id, conn.id, port=5433, description="Updated")
 
 # Delete
-client.connectors.delete(conn.id)
+client.connectors.delete(project_id, conn.id)
 ```
 
 Test connection (basic):
 ```python
-ok = client.connectors.test_connection(conn.id)
+ok = client.connectors.test_connection(project_id, conn.id)
 ```
 
 Test connection (detailed):
@@ -45,7 +47,7 @@ details = client.connectors.test_connection_detailed(conn.id)
 
 Filter by type:
 ```python
-pg = client.connectors.list_by_type("postgres")
+pg = client.connectors.list_by_type(project_id, "postgres")
 ```
 
 Snowflake connector example:

--- a/docs/quick-start/developer-starter-guide.md
+++ b/docs/quick-start/developer-starter-guide.md
@@ -388,6 +388,7 @@ print("🔌 Creating Snowflake connector...")
 
 try:
     snowflake_connector = sdk_client.connectors.create(
+        project_id=project.id,
         name="H2O Drive Analytics Warehouse",
         description="Snowflake data warehouse for H2O Drive analytics and processed data",
         db_type="snowflake",
@@ -407,7 +408,7 @@ try:
     print(f"   Name: {snowflake_connector.name}")
     
     # Test the connection
-    connection_ok = sdk_client.connectors.test_connection(snowflake_connector.id)
+    connection_ok = sdk_client.connectors.test_connection(project.id, snowflake_connector.id)
     if connection_ok:
         print("✅ Snowflake connection test successful!")
     else:
@@ -421,8 +422,8 @@ except Exception as e:
 ### 3.3 List and Manage Connectors
 
 ```python
-# List all connectors
-all_connectors = sdk_client.connectors.list()
+# List all connectors in project
+all_connectors = sdk_client.connectors.list(project.id)
 snowflake_connectors = [c for c in all_connectors if c.db_type.lower() == "snowflake"]
 
 print(f"📋 Found {len(snowflake_connectors)} Snowflake connector(s):")

--- a/docs/quick-start/quick-reference.md
+++ b/docs/quick-start/quick-reference.md
@@ -77,6 +77,7 @@ print(f"Project ID: {project.id}")
 ### 4. Snowflake Connector
 ```python
 snowflake_connector = sdk_client.connectors.create(
+    project_id=project.id,
     name="Snowflake Warehouse",
     db_type="snowflake",
     host=os.getenv("SNOWFLAKE_ACCOUNT"),
@@ -312,7 +313,7 @@ for p in projects:
     print(f"{p.name} (ID: {p.id})")
 
 # List connectors
-connectors = sdk_client.connectors.list()
+connectors = sdk_client.connectors.list(project.id)
 for c in connectors:
     print(f"{c.name} ({c.db_type}) - ID: {c.id}")
 

--- a/documentation/docs/guides/connectors.md
+++ b/documentation/docs/guides/connectors.md
@@ -10,8 +10,10 @@ from text2everything_sdk import Text2EverythingClient
 
 client = Text2EverythingClient(base_url="https://...", access_token="...", workspace_name="workspaces/dev")
 
-# Create
+# Create in a project
+project_id = client.projects.create(name="Demo").id
 conn = client.connectors.create(
+    project_id=project_id,
     name="Production DB",
     db_type="postgres",
     host="db.example.com",
@@ -21,31 +23,31 @@ conn = client.connectors.create(
     database="production",
 )
 
-# List / get
-connectors = client.connectors.list()
-one = client.connectors.get(conn.id)
+# List / get in project
+connectors = client.connectors.list(project_id)
+one = client.connectors.get(project_id, conn.id)
 
 # Update
-updated = client.connectors.update(conn.id, port=5433, description="Updated")
+updated = client.connectors.update(project_id, conn.id, port=5433, description="Updated")
 
 # Delete
-client.connectors.delete(conn.id)
+client.connectors.delete(project_id, conn.id)
 ```
 
 Test connection (basic):
 ```python
-ok = client.connectors.test_connection(conn.id)
+ok = client.connectors.test_connection(project_id, conn.id)
 ```
 
 Test connection (detailed):
 ```python
-details = client.connectors.test_connection_detailed(conn.id)
+details = client.connectors.test_connection_detailed(project_id, conn.id)
 # {'ok': True, 'elapsed_ms': 123}
 ```
 
 Filter by type:
 ```python
-pg = client.connectors.list_by_type("postgres")
+pg = client.connectors.list_by_type(project_id, "postgres")
 ```
 
 Snowflake connector example:
@@ -55,6 +57,7 @@ from text2everything_sdk import Text2EverythingClient
 client = Text2EverythingClient(base_url="https://...", access_token="...", workspace_name="workspaces/dev")
 
 snowflake_conn = client.connectors.create(
+    project_id=project_id,
     name="Snowflake - Analytics",
     db_type="snowflake",
     host="<account>.<region>.snowflakecomputing.com",
@@ -69,8 +72,8 @@ snowflake_conn = client.connectors.create(
 )
 
 # Optional: test the connection
-ok = client.connectors.test_connection(snowflake_conn.id)
-details = client.connectors.test_connection_detailed(snowflake_conn.id)
+ok = client.connectors.test_connection(project_id, snowflake_conn.id)
+details = client.connectors.test_connection_detailed(project_id, snowflake_conn.id)
 ```
 
 

--- a/documentation/docs/quick-start/developer-starter-guide.md
+++ b/documentation/docs/quick-start/developer-starter-guide.md
@@ -387,6 +387,7 @@ print("🔌 Creating Snowflake connector...")
 
 try:
     snowflake_connector = sdk_client.connectors.create(
+        project_id=project.id,
         name="H2O Drive Analytics Warehouse",
         description="Snowflake data warehouse for H2O Drive analytics and processed data",
         db_type="snowflake",
@@ -406,7 +407,7 @@ try:
     print(f"   Name: {snowflake_connector.name}")
     
     # Test the connection
-    connection_ok = sdk_client.connectors.test_connection(snowflake_connector.id)
+    connection_ok = sdk_client.connectors.test_connection(project.id, snowflake_connector.id)
     if connection_ok:
         print("✅ Snowflake connection test successful!")
     else:
@@ -420,8 +421,8 @@ except Exception as e:
 ### 3.3 List and Manage Connectors
 
 ```python
-# List all connectors
-all_connectors = sdk_client.connectors.list()
+# List all connectors in project
+all_connectors = sdk_client.connectors.list(project.id)
 snowflake_connectors = [c for c in all_connectors if c.db_type.lower() == "snowflake"]
 
 print(f"📋 Found {len(snowflake_connectors)} Snowflake connector(s):")

--- a/documentation/docs/quick-start/integration-summary.md
+++ b/documentation/docs/quick-start/integration-summary.md
@@ -66,7 +66,7 @@ contexts = sdk_client.contexts.bulk_create(project_id=project.id, contexts=sdk_r
 **Step 2: Text2Everything → Step 3: Snowflake**
 ```python
 # T2E project connects to Snowflake for SQL execution
-snowflake_connector = sdk_client.connectors.create(...)
+snowflake_connector = sdk_client.connectors.create(project_id=project.id, ...)
 answer_response = sdk_client.chat.chat_to_answer(
     project_id=project.id,
     connector_id=snowflake_connector.id,

--- a/documentation/docs/quick-start/quick-reference.md
+++ b/documentation/docs/quick-start/quick-reference.md
@@ -76,6 +76,7 @@ print(f"Project ID: {project.id}")
 ### 4. Snowflake Connector
 ```python
 snowflake_connector = sdk_client.connectors.create(
+    project_id=project.id,
     name="Snowflake Warehouse",
     db_type="snowflake",
     host=os.getenv("SNOWFLAKE_ACCOUNT"),
@@ -190,7 +191,7 @@ async def quick_test():
     
     # Snowflake (if configured)
     if snowflake_connector:
-        ok = sdk_client.connectors.test_connection(snowflake_connector.id)
+        ok = sdk_client.connectors.test_connection(project.id, snowflake_connector.id)
         print(f"Snowflake: {'✅' if ok else '❌'}")
 
 await quick_test()
@@ -310,7 +311,7 @@ for p in projects:
     print(f"{p.name} (ID: {p.id})")
 
 # List connectors
-connectors = sdk_client.connectors.list()
+connectors = sdk_client.connectors.list(project.id)
 for c in connectors:
     print(f"{c.name} ({c.db_type}) - ID: {c.id}")
 

--- a/models/connectors.py
+++ b/models/connectors.py
@@ -53,5 +53,7 @@ class ConnectorUpdate(BaseModel):
 
 class Connector(ConnectorBase, BaseResponse):
     """Complete connector model with all fields."""
+    # Backward compatibility: older connectors may not have project_id
+    project_id: Optional[str] = None
     # From API responses: full secure store resource name
     password_secret_name: Optional[str] = None

--- a/models/executions.py
+++ b/models/executions.py
@@ -23,6 +23,7 @@ class SQLExecuteResponse(BaseModel):
     """Model for SQL execution response."""
     
     execution_id: str
+    project_id: str
     connector_id: str
     sql_query: str
     result: Dict[str, Any]
@@ -33,6 +34,7 @@ class SQLExecuteResponse(BaseModel):
 class ExecutionBase(BaseModel):
     """Base execution model."""
     
+    project_id: str
     result: Dict[str, Any]
     execution_time_ms: int
     chat_message_id: Optional[str] = None
@@ -48,6 +50,7 @@ class Execution(ExecutionBase, BaseResponse):
 class ExecutionListItem(BaseResponse):
     """Execution summary item for list endpoints (no result payload)."""
 
+    project_id: str
     execution_time_ms: int
     is_successful: bool
     chat_message_id: Optional[str] = None

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -97,7 +97,7 @@ class BaseTestRunner:
                     elif resource_type == 'golden_examples':
                         self.client.golden_examples.delete(self.test_project_id, resource_id)
                     elif resource_type == 'connectors':
-                        self.client.connectors.delete(resource_id)
+                        self.client.connectors.delete(self.test_project_id, resource_id)
                     elif resource_type == 'chat_sessions':
                         self.client.chat_sessions.delete(self.test_project_id, resource_id)
                     elif resource_type == 'feedback':

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -16,6 +16,7 @@ class ConnectorsTestRunner(BaseTestRunner):
         try:
             # Test create PostgreSQL connector
             connector_result = self.client.connectors.create(
+                project_id=self.test_project_id,
                 name="test_postgres_connector",
                 description="PostgreSQL connector for functional testing",
                 db_type="postgres",
@@ -66,6 +67,7 @@ class ConnectorsTestRunner(BaseTestRunner):
                     cfg["private_key_passphrase_secret_name"] = sf_pk_pass_secret_name
 
                 snowflake_keypair = self.client.connectors.create(
+                    project_id=self.test_project_id,
                     name="h2o-snowflake-connector-keypair",
                     description="H2O AI Snowflake connector (key-pair)",
                     db_type="snowflake",
@@ -80,6 +82,7 @@ class ConnectorsTestRunner(BaseTestRunner):
 
             if all([sf_host, sf_user, sf_db]) and (sf_pwd or sf_pwd_secret_id):
                 snowflake_password = self.client.connectors.create(
+                    project_id=self.test_project_id,
                     name="h2o-snowflake-connector-password",
                     description="H2O AI Snowflake connector (password)",
                     db_type="snowflake",
@@ -101,16 +104,17 @@ class ConnectorsTestRunner(BaseTestRunner):
                 print("⚠️  Skipping Snowflake connector creation (missing env vars for both methods)")
             
             # Test list connectors
-            connectors = self.client.connectors.list()
+            connectors = self.client.connectors.list(self.test_project_id)
             print(f"✅ Listed {len(connectors)} connectors")
             
             # Test get connector
-            retrieved_connector = self.client.connectors.get(connector_result.id)
+            retrieved_connector = self.client.connectors.get(self.test_project_id, connector_result.id)
             print(f"✅ Retrieved connector: {retrieved_connector.name}")
             
             # Test update connector (don't fail suite if this errors)
             try:
                 updated_connector = self.client.connectors.update(
+                    self.test_project_id,
                     connector_result.id,
                     description="Updated PostgreSQL connector description"
                 )
@@ -120,9 +124,11 @@ class ConnectorsTestRunner(BaseTestRunner):
             
             # Test list by type (non-blocking)
             try:
-                postgres_connectors = self.client.connectors.list_by_type("postgres")
-                snowflake_connectors = self.client.connectors.list_by_type("snowflake")
-                print(f"✅ Found {len(postgres_connectors)} PostgreSQL and {len(snowflake_connectors)} Snowflake connectors")
+                # list_by_type now requires explicit project scoping; filter client-side
+                all_connectors = self.client.connectors.list(self.test_project_id)
+                postgres_connectors = [c for c in all_connectors if c.db_type.lower() == "postgres"]
+                snowflake_connectors = [c for c in all_connectors if c.db_type.lower() == "snowflake"]
+                print(f"✅ Found {len(postgres_connectors)} PostgreSQL and {len(snowflake_connectors)} Snowflake connectors in project")
             except Exception as e:
                 print(f"⚠️  List by type skipped due to error: {e}")
             
@@ -142,13 +148,13 @@ class ConnectorsTestRunner(BaseTestRunner):
             for c in created_connectors:
                 # Boolean/ok-style test
                 try:
-                    ok = self.client.connectors.test_connection(c.id)
+                    ok = self.client.connectors.test_connection(self.test_project_id, c.id)
                     print(f"✅ test_connection ok={ok} for {c.name} ({c.id})")
                 except Exception as e:
                     print(f"⚠️  test_connection failed for {c.name} ({c.id}): {e}")
                 # Detailed test
                 try:
-                    detail = self.client.connectors.test_connection_detailed(c.id)
+                    detail = self.client.connectors.test_connection_detailed(self.test_project_id, c.id)
                     elapsed = detail.get('elapsed_ms') if isinstance(detail, dict) else None
                     print(f"✅ test_connection_detailed ok={detail.get('ok', False) if isinstance(detail, dict) else detail} elapsed_ms={elapsed} for {c.name} ({c.id})")
                 except Exception as e:

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -33,6 +33,7 @@ class ExecutionsTestRunner(BaseTestRunner):
             # Test SQL execution
             try:
                 execution_result = self.client.executions.execute_sql(
+                    self.test_project_id,
                     sql_query="SELECT 1 as test_column;",
                     connector_id=connector_id
                 )
@@ -66,6 +67,7 @@ class ExecutionsTestRunner(BaseTestRunner):
                 
                 # Now test execution from the real chat message
                 chat_execution = self.client.executions.execute_from_chat(
+                    self.test_project_id,
                     connector_id=connector_id,
                     chat_message_id=real_message_id,
                     chat_session_id=chat_session_id

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -19,7 +19,7 @@ class FeedbackTestRunner(BaseTestRunner):
             
             # Try to find existing h2o-snowflake-connector
             try:
-                connectors = self.client.connectors.list()
+                connectors = self.client.connectors.list(self.test_project_id)
                 for connector in connectors:
                     if connector.name == "h2o-snowflake-connector":
                         connector_id = connector.id
@@ -40,6 +40,7 @@ class FeedbackTestRunner(BaseTestRunner):
                         os.getenv("SNOWFLAKE_DATABASE")
                     ]):
                         connector_result = self.client.connectors.create(
+                            project_id=self.test_project_id,
                             name="h2o-snowflake-connector",
                             description="H2O AI Snowflake connector for feedback testing",
                             db_type="snowflake",
@@ -59,6 +60,7 @@ class FeedbackTestRunner(BaseTestRunner):
                     else:
                         # Fallback postgres connector for local testing
                         connector_result = self.client.connectors.create(
+                            project_id=self.test_project_id,
                             name="feedback-test-postgres-connector",
                             description="PostgreSQL connector for feedback testing",
                             db_type="postgres",
@@ -110,6 +112,7 @@ class FeedbackTestRunner(BaseTestRunner):
             execution_id = None
             try:
                 execution_response = self.client.executions.execute_sql(
+                    self.test_project_id,
                     connector_id=connector_id,
                     chat_message_id=chat_message_id
                 )


### PR DESCRIPTION
This pull request updates the SDK and documentation to require a `project_id` parameter for all connector-related operations, ensuring connectors are always associated with a specific project. This change affects both the SDK API and all related documentation and guides, making connector management project-scoped and improving clarity and consistency across the codebase.

**SDK API changes (breaking and behavioral):**

- All connector operations (`create`, `get`, `list`, `update`, `delete`, `test_connection`, etc.) now require a `project_id` as the first argument, and endpoints are constructed to be project-scoped. This is a breaking change that enforces connectors to be managed within the context of a project. [[1]](diffhunk://#diff-6c4b911abfcff9ed3708834703f573fb1d9ced13f0f470cc44c960bfc04b05d3R28) [[2]](diffhunk://#diff-6c4b911abfcff9ed3708834703f573fb1d9ced13f0f470cc44c960bfc04b05d3L127-R119) [[3]](diffhunk://#diff-6c4b911abfcff9ed3708834703f573fb1d9ced13f0f470cc44c960bfc04b05d3L144-R139) [[4]](diffhunk://#diff-6c4b911abfcff9ed3708834703f573fb1d9ced13f0f470cc44c960bfc04b05d3L163-R176) [[5]](diffhunk://#diff-6c4b911abfcff9ed3708834703f573fb1d9ced13f0f470cc44c960bfc04b05d3R212)
- The `Connector` model now includes an optional `project_id` field for backward compatibility.

**Documentation and usage updates:**

- All code samples and guides in `README.md`, `docs/guides/connectors.md`, `docs/quick-start/developer-starter-guide.md`, `docs/quick-start/quick-reference.md`, and their equivalents in `documentation/docs/` have been updated to show usage of the new `project_id` parameter in all connector method calls. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R240) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L250-R251) [[3]](diffhunk://#diff-7c9451a6dc30214e951008b65fb96d150445f4964dd17ccac5d9ab2d93aef6f6L13-R16) [[4]](diffhunk://#diff-7c9451a6dc30214e951008b65fb96d150445f4964dd17ccac5d9ab2d93aef6f6L24-R39) [[5]](diffhunk://#diff-7c9451a6dc30214e951008b65fb96d150445f4964dd17ccac5d9ab2d93aef6f6L48-R50) [[6]](diffhunk://#diff-e2a750f7591a10dd64bed6ec95cb52f7f90eb4fbb12f6e91f5d31c4cfb3946c8R391) [[7]](diffhunk://#diff-e2a750f7591a10dd64bed6ec95cb52f7f90eb4fbb12f6e91f5d31c4cfb3946c8L410-R411) [[8]](diffhunk://#diff-e2a750f7591a10dd64bed6ec95cb52f7f90eb4fbb12f6e91f5d31c4cfb3946c8L424-R426) [[9]](diffhunk://#diff-013083b4f6efff388de01d868a70321c5830367ce6be717447bfac731d1a7ec0R80) [[10]](diffhunk://#diff-013083b4f6efff388de01d868a70321c5830367ce6be717447bfac731d1a7ec0L315-R316) [[11]](diffhunk://#diff-1badac5ee0f4b04a11c3e65a64e5fa6efe7c5bfa7f850435fb7dc223bcb7945eL13-R16) [[12]](diffhunk://#diff-1badac5ee0f4b04a11c3e65a64e5fa6efe7c5bfa7f850435fb7dc223bcb7945eL24-R50) [[13]](diffhunk://#diff-1badac5ee0f4b04a11c3e65a64e5fa6efe7c5bfa7f850435fb7dc223bcb7945eR60) [[14]](diffhunk://#diff-1badac5ee0f4b04a11c3e65a64e5fa6efe7c5bfa7f850435fb7dc223bcb7945eL72-R76) [[15]](diffhunk://#diff-7cd357d3fab99dfd7c727c83092c413b39719846448eb40467ff08534c9cda5eR390) [[16]](diffhunk://#diff-7cd357d3fab99dfd7c727c83092c413b39719846448eb40467ff08534c9cda5eL409-R410) [[17]](diffhunk://#diff-7cd357d3fab99dfd7c727c83092c413b39719846448eb40467ff08534c9cda5eL423-R425) [[18]](diffhunk://#diff-61a92f15a7be15a7504b407b8238f0feca4253bd0ccf972ce0639fb6a8091c0aL69-R69) [[19]](diffhunk://#diff-c5384d189a2651e51ee1f1147d3ca9964648ae63baa2c7c61c4f1816b7687c41R79) [[20]](diffhunk://#diff-c5384d189a2651e51ee1f1147d3ca9964648ae63baa2c7c61c4f1816b7687c41L193-R194) [[21]](diffhunk://#diff-c5384d189a2651e51ee1f1147d3ca9964648ae63baa2c7c61c4f1816b7687c41L313-R314)

**Model changes:**

- The SQL execution and execution summary models now include a `project_id` field to track the project context for executions. [[1]](diffhunk://#diff-3ad081c370a6038beff526ebf01165bb79d7b690fd6574a9a5c8aab9808c6f75R26) [[2]](diffhunk://#diff-3ad081c370a6038beff526ebf01165bb79d7b690fd6574a9a5c8aab9808c6f75R37) [[3]](diffhunk://#diff-3ad081c370a6038beff526ebf01165bb79d7b690fd6574a9a5c8aab9808c6f75R53)

These changes ensure that all connector operations are explicitly tied to a project, improving security, clarity, and multi-project support. Existing code using connector APIs will need to be updated to include a `project_id` argument.